### PR TITLE
change extension from .json to .sol

### DIFF
--- a/src/store/gnosis/contracts.js
+++ b/src/store/gnosis/contracts.js
@@ -1,8 +1,8 @@
 import CONDITIONAL_TOKENS_JSON from '@gnosis-contracts/conditional-tokens-contracts/build/contracts/ConditionalTokens'
 import WHITELIST_JSON from '@gnosis-contracts/conditional-tokens-contracts/build/contracts/ConditionalTokens'
-import ORCHESTRATOR_JSON from '@contracts/SignallingOrchestrator.json'
-import MM_JSON from '@contracts/MarketMaker.json'
-import COLLATERAL_JSON from '@contracts/CollateralToken.json'
+import ORCHESTRATOR_JSON from '@contracts/SignallingOrchestrator.sol'
+import MM_JSON from '@contracts/MarketMaker.sol'
+import COLLATERAL_JSON from '@contracts/CollateralToken.sol'
 const ethers = require('ethers');
 
 const MARKET_MAKER_FACTORY = '0x7837aA552989D8B1D91364D97c4a7002119C490D';


### PR DESCRIPTION
`npm run dev` fails with error: 

`These dependancies were not found 
@contracts/CollateralToken.json in ./src/store/gnosis/contracts.js
@contracts/MarketMaker.json in ./src/store/gnosis/contracts.js
@contracts/SignallingOrchesttrator.json in ./src/store/gnosis/contracts.js
`

Looked at `contracts.js` and found files saved with the solidity extension. This commit rectifies this and it worked for me. Kindly correct me if this is an error on my end. 